### PR TITLE
Updates TheSideBarController for use with AutoLayout

### DIFF
--- a/Examples/KitchenSink/KitchenSink.xcodeproj/project.pbxproj
+++ b/Examples/KitchenSink/KitchenSink.xcodeproj/project.pbxproj
@@ -338,7 +338,7 @@
 		1781F319187AE4060061DCC4 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0500;
+				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Jon Danao (danao.org | jondanao)";
 				TargetAttributes = {
 					1781F33B187AE4060061DCC4 = {
@@ -451,7 +451,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -491,7 +490,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
@@ -552,7 +550,6 @@
 		1781F351187AE4060061DCC4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/KitchenSink.app/KitchenSink";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
@@ -575,7 +572,6 @@
 		1781F352187AE4060061DCC4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/KitchenSink.app/KitchenSink";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",

--- a/TheSidebarController/TheSidebarController.h
+++ b/TheSidebarController/TheSidebarController.h
@@ -1,6 +1,6 @@
 // TheSidebarController.h
 // TheSidebarController
-// 
+//
 // Copyright (c) 2013 Jon Danao (danao.org | jondanao)
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -9,10 +9,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -37,6 +37,7 @@
 @property (assign, nonatomic) CGFloat visibleWidth;
 @property (assign, nonatomic) BOOL sidebarIsPresenting;
 @property (assign, nonatomic) id<TheSidebarControllerDelegate> delegate;
+@property (assign, nonatomic) BOOL storyboardsUseAutolayout;
 
 - (id)initWithContentViewController:(UIViewController *)contentViewController
           leftSidebarViewController:(UIViewController *)leftSidebarViewController;
@@ -47,6 +48,19 @@
 - (id)initWithContentViewController:(UIViewController *)contentViewController
           leftSidebarViewController:(UIViewController *)leftSidebarViewController
          rightSidebarViewController:(UIViewController *)rightSidebarViewController;
+
+- (id)initWithContentViewController:(UIViewController *)contentViewController
+          leftSidebarViewController:(UIViewController *)leftSidebarViewController
+           storyboardsUseAutoLayout:(BOOL)storyboardsUseAutoLayout;
+
+- (id)initWithContentViewController:(UIViewController *)contentViewController
+         rightSidebarViewController:(UIViewController *)rightSidebarViewController
+           storyboardsUseAutoLayout:(BOOL)storyboardsUseAutoLayout;
+
+- (id)initWithContentViewController:(UIViewController *)contentViewController
+          leftSidebarViewController:(UIViewController *)leftSidebarViewController
+         rightSidebarViewController:(UIViewController *)rightSidebarViewController
+           storyboardsUseAutoLayout:(BOOL)storyboardsUseAutoLayout;
 
 - (void)dismissSidebarViewController;
 - (void)presentLeftSidebarViewController;

--- a/TheSidebarController/TheSidebarController.m
+++ b/TheSidebarController/TheSidebarController.m
@@ -88,6 +88,30 @@ static const CGFloat kVisibleWidth = 260.0f;
     return self;
 }
 
+- (id)initWithContentViewController:(UIViewController *)contentViewController
+          leftSidebarViewController:(UIViewController *)leftSidebarViewController
+           storyboardsUseAutoLayout:(BOOL)storyboardsUseAutoLayout
+{
+    self.storyboardsUseAutolayout = storyboardsUseAutoLayout;
+    return [self initWithContentViewController:contentViewController leftSidebarViewController:leftSidebarViewController];
+}
+
+- (id)initWithContentViewController:(UIViewController *)contentViewController
+         rightSidebarViewController:(UIViewController *)rightSidebarViewController
+           storyboardsUseAutoLayout:(BOOL)storyboardsUseAutoLayout
+{
+    self.storyboardsUseAutolayout = storyboardsUseAutoLayout;
+    return [self initWithContentViewController:contentViewController rightSidebarViewController:rightSidebarViewController];
+}
+
+- (id)initWithContentViewController:(UIViewController *)contentViewController
+          leftSidebarViewController:(UIViewController *)leftSidebarViewController
+         rightSidebarViewController:(UIViewController *)rightSidebarViewController
+           storyboardsUseAutoLayout:(BOOL)storyboardsUseAutoLayout
+{
+    self.storyboardsUseAutolayout = storyboardsUseAutoLayout;
+    return [self initWithContentViewController:contentViewController leftSidebarViewController:leftSidebarViewController rightSidebarViewController:rightSidebarViewController];
+}
 
 #pragma mark - UIViewController Lifecycle
 - (void)viewDidLoad
@@ -95,7 +119,7 @@ static const CGFloat kVisibleWidth = 260.0f;
     NSAssert(self.contentViewController != nil, @"contentViewController was not set");
     
     [super viewDidLoad];
-    self.view.translatesAutoresizingMaskIntoConstraints = NO;
+    self.view.translatesAutoresizingMaskIntoConstraints = self.storyboardsUseAutolayout;
     self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     
     if(self.leftSidebarViewController)
@@ -104,7 +128,7 @@ static const CGFloat kVisibleWidth = 260.0f;
         [self addChildViewController:self.leftSidebarContainerViewController];
         [self.view addSubview:self.leftSidebarContainerViewController.view];
         [self.leftSidebarContainerViewController didMoveToParentViewController:self];
-        self.leftSidebarContainerViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
+        self.leftSidebarContainerViewController.view.translatesAutoresizingMaskIntoConstraints = self.storyboardsUseAutolayout;
         self.leftSidebarContainerViewController.view.hidden = YES;
         
         // Child View Controller
@@ -119,7 +143,7 @@ static const CGFloat kVisibleWidth = 260.0f;
         [self addChildViewController:self.rightSidebarContainerViewController];
         [self.view addSubview:self.rightSidebarContainerViewController.view];
         [self.rightSidebarContainerViewController didMoveToParentViewController:self];
-        self.rightSidebarContainerViewController.view.translatesAutoresizingMaskIntoConstraints = NO;
+        self.rightSidebarContainerViewController.view.translatesAutoresizingMaskIntoConstraints = self.storyboardsUseAutolayout;
         self.rightSidebarContainerViewController.view.hidden = YES;
         
         // Child View Controller
@@ -192,7 +216,7 @@ static const CGFloat kVisibleWidth = 260.0f;
 
 #pragma mark - TheSidebarController Private Methods
 - (void)showSidebarViewControllerFromSide:(Side)side withTransitionStyle:(SidebarTransitionStyle)transitionStyle
-{    
+{
     [[UIApplication sharedApplication] beginIgnoringInteractionEvents];
     self.view.autoresizingMask = UIViewAutoresizingNone;
     


### PR DESCRIPTION
If you are using AutoLayout in your storyboards, setting translatesAutoresizingMaskIntoConstraints to NO causes issues with responsiveness of the menus as well as layout of the main content view. I have added 3 new constructors as well as a new property to handle the issue.
