### PR TITLE
Fix import header for compatibility with Cocoapods v0.39.x

### DIFF
--- a/TheSidebarController/TheSidebarController.h
+++ b/TheSidebarController/TheSidebarController.h
@@ -23,7 +23,7 @@
 
 
 #import <UIKit/UIKit.h>
-#import "SidebarAnimation.h"
+#import "Animations/SidebarAnimation.h"
 
 @protocol TheSidebarControllerDelegate;
 


### PR DESCRIPTION
Since CocoaPods 0.39.0 there is a requirement to define file paths in import statements, due to conflicting pods projects which share a common file name. Attempting to compile a project using TheSidebarController with Cocoapods 0.39.0 will fail.  This fix will resolve.
