### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ This project is inspired by [RESideMenu](https://github.com/romaonthego/RESideMe
 
 Drag and drop `TheSidebarController` folder into your project. Add `#import "TheSidebarController.h"` to all view controllers that need to use it.
 
-### Cocoapods
+### CocoaPods
 
-Cocoapods is amazing. If you're still not using it, start now! This is the recommended approach to manage your dependencies. Learn from their official website: [http://guides.cocoapods.org/](http://guides.cocoapods.org/)
+CocoaPods is amazing. If you're still not using it, start now! This is the recommended approach to manage your dependencies. Learn from their official website: [http://guides.cocoapods.org/](http://guides.cocoapods.org/)
 
 In the project folder where .xcodeproj resides, **create a Podfile:**
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
